### PR TITLE
C05 - añade lógica de marcación diaria y cálculo de racha

### DIFF
--- a/src/controllers/habit.controller.ts
+++ b/src/controllers/habit.controller.ts
@@ -8,6 +8,7 @@ import {
   getHabitById,
   updateHabit,
   deleteHabit,
+  markHabit,
 } from '../services/habit.service';
 import { HttpError } from '../services/user.service';
 import { AuthRequest } from '../middlewares/auth.middleware';
@@ -146,6 +147,32 @@ export async function deleteHabitHandler(
     // 2. Eliminar y devolver 204
     deleteHabit(habitId, userId);
     res.sendStatus(204);
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    if (err instanceof Error) {
+      res.status(500).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: 'Error interno del servidor' });
+  }
+}
+
+/**
+ * Maneja POST /api/habits/:habitId/check
+ */
+export async function markHabitHandler(
+  req: AuthRequest,
+  res: Response,
+): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const { habitId } = req.params;
+
+    const result = markHabit(userId, habitId);
+    res.status(200).json(result);
   } catch (err: unknown) {
     if (err instanceof HttpError) {
       res.status(err.status).json({ message: err.message });

--- a/src/routes/habit.routes.ts
+++ b/src/routes/habit.routes.ts
@@ -4,6 +4,7 @@ import {
   getHabitsHandler,
   updateHabitHandler,
   deleteHabitHandler,
+  markHabitHandler,
 } from '../controllers/habit.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 
@@ -14,5 +15,6 @@ router.post('/', createHabitHandler);
 router.get('/', getHabitsHandler);
 router.put('/:habitId', updateHabitHandler);
 router.delete('/:habitId', deleteHabitHandler);
+router.post('/:habitId/check', markHabitHandler);
 
 export default router;

--- a/tests/habits/checkHabit.test.ts
+++ b/tests/habits/checkHabit.test.ts
@@ -1,0 +1,72 @@
+import request from 'supertest';
+import app from '../../src/index';
+import { createUser } from '../../src/services/user.service';
+import { createHabit, habitStore } from '../../src/services/habit.service';
+import jwt from 'jsonwebtoken';
+
+describe('C05: POST /api/habits/:habitId/check', () => {
+  let authToken: string;
+  let userId: string;
+  let habitId: string;
+
+  beforeAll(async () => {
+    // 1. Crear usuario y token
+    const user = await createUser('checkuser@test.com', 'secret123');
+    userId = user.id;
+    authToken = jwt.sign(
+      { sub: userId, email: 'checkuser@test.com' },
+      process.env.JWT_SECRET!,
+      { expiresIn: '1h' },
+    );
+  });
+
+  beforeEach(() => {
+    // Crear el hábito de prueba antes de cada test
+    const habit = createHabit(userId, 'hacer ejercicio', 'Descripción');
+    habitId = habit.id;
+  });
+
+  afterEach(() => {
+    habitStore.clear();
+  });
+
+  it('debe devolver 401 si no se envía token', async () => {
+    const res = await request(app).post(`/api/habits/${habitId}/check`);
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Token inválido o expirado');
+  });
+
+  it('debe devolver 404 si el hábito no existe', async () => {
+    habitStore.clear();
+    const res = await request(app)
+      .post(`/api/habits/no-existe-uuid/check`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Hábito no encontrado');
+  });
+
+  it('debe devolver 400 si ya se marcó hoy', async () => {
+    // Primera marca OK
+    await request(app)
+      .post(`/api/habits/${habitId}/check`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    // Segundo intento, debe fallar
+    const res2 = await request(app)
+      .post(`/api/habits/${habitId}/check`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res2.status).toBe(400);
+    expect(res2.body.message).toBe('Ya has marcado este hábito hoy');
+  });
+
+  it('debe devolver 200 con date y currentStreak correcto', async () => {
+    const res = await request(app)
+      .post(`/api/habits/${habitId}/check`)
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('habitId', habitId);
+    expect(res.body).toHaveProperty('date');
+    expect(res.body).toHaveProperty('currentStreak', 1);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Descripción

- Agrega `checkStore` en memoria para almacenar fechas de “check” por hábito y usuario.
- Implementa `markHabit(userId, habitId)` en `habit.service.ts`: • Verifica existencia y propiedad del hábito (errores 404/403). • Evita duplicados diarios (error 400 si ya marcado hoy). • Añade la fecha de hoy y calcula la racha iterando días anteriores.
- Refactoriza bucles para eliminar `while(true)` y usar condición sobre fechas.
- Ajusta variables mutables a `const` según preferencia de ESLint.

## Tipo de cambio

- [ ] Arreglo de comportamiento
- [x] Nueva caracteristica
- [ ] Documentación

## Checklist

- [x] He leído CONTRIBUTING.md
- [x] Mi código sigue las pautas de estilo (lint y prettier)
- [x] Añadí tests si son necesarios
- [x] CI pasa sin errores
