### PR TITLE
C06 - Consultar racha

### DIFF
--- a/src/controllers/habit.controller.ts
+++ b/src/controllers/habit.controller.ts
@@ -9,6 +9,7 @@ import {
   updateHabit,
   deleteHabit,
   markHabit,
+  getHabitStreak,
 } from '../services/habit.service';
 import { HttpError } from '../services/user.service';
 import { AuthRequest } from '../middlewares/auth.middleware';
@@ -172,6 +173,32 @@ export async function markHabitHandler(
     const { habitId } = req.params;
 
     const result = markHabit(userId, habitId);
+    res.status(200).json(result);
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    if (err instanceof Error) {
+      res.status(500).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: 'Error interno del servidor' });
+  }
+}
+
+/**
+ * Maneja GET /api/habits/:habitId/streak
+ */
+export async function getHabitStreakHandler(
+  req: AuthRequest,
+  res: Response,
+): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const { habitId } = req.params;
+
+    const result = getHabitStreak(userId, habitId);
     res.status(200).json(result);
   } catch (err: unknown) {
     if (err instanceof HttpError) {

--- a/src/routes/habit.routes.ts
+++ b/src/routes/habit.routes.ts
@@ -5,6 +5,7 @@ import {
   updateHabitHandler,
   deleteHabitHandler,
   markHabitHandler,
+  getHabitStreakHandler,
 } from '../controllers/habit.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 
@@ -16,5 +17,6 @@ router.get('/', getHabitsHandler);
 router.put('/:habitId', updateHabitHandler);
 router.delete('/:habitId', deleteHabitHandler);
 router.post('/:habitId/check', markHabitHandler);
+router.get('/:habitId/streak', getHabitStreakHandler);
 
 export default router;

--- a/tests/habits/getStreak.test.ts
+++ b/tests/habits/getStreak.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import app from '../../src/index';
+import { createUser } from '../../src/services/user.service';
+import { createHabit, habitStore } from '../../src/services/habit.service';
+import { markHabit } from '../../src/services/habit.service';
+import jwt from 'jsonwebtoken';
+
+describe('C06: GET /api/habits/:habitId/streak', () => {
+  let authToken: string;
+  let userId: string;
+  let habitId: string;
+
+  beforeAll(async () => {
+    const user = await createUser('streak@test.com', 'secret123');
+    userId = user.id;
+    authToken = jwt.sign(
+      { sub: userId, email: 'streak@test.com' },
+      process.env.JWT_SECRET!,
+      { expiresIn: '1h' },
+    );
+  });
+
+  beforeEach(() => {
+    const habit = createHabit(userId, 'leer diario');
+    habitId = habit.id;
+  });
+
+  afterEach(() => {
+    habitStore.clear();
+  });
+
+  it('debe devolver 401 si falta token', async () => {
+    const res = await request(app).get(`/api/habits/${habitId}/streak`);
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Token inválido o expirado');
+  });
+
+  it('debe devolver 404 si el hábito no existe', async () => {
+    habitStore.clear();
+    const res = await request(app)
+      .get(`/api/habits/no-existe-uuid/streak`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Hábito no encontrado');
+  });
+
+  it('debe devolver 403 si hábito de otro usuario', async () => {
+    // Crear otro usuario y token
+    const other = await createUser('otro@test.com', 'secret123');
+    const otherToken = jwt.sign(
+      { sub: other.id, email: 'otro@test.com' },
+      process.env.JWT_SECRET!,
+      { expiresIn: '1h' },
+    );
+
+    const res = await request(app)
+      .get(`/api/habits/${habitId}/streak`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toBe('No autorizado');
+  });
+
+  it('debe devolver 0 si no hay checks', async () => {
+    const res = await request(app)
+      .get(`/api/habits/${habitId}/streak`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ habitId, currentStreak: 0 });
+  });
+
+  it('debe devolver racha=1 tras un check', async () => {
+    // marcamos hoy
+    markHabit(userId, habitId);
+
+    const res = await request(app)
+      .get(`/api/habits/${habitId}/streak`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        habitId,
+        currentStreak: 1,
+        lastCheck: expect.any(String),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
# Pull Request

## Descripción
- Servicio `getHabitStreak(userId, habitId)`: • Valida existencia (404) y pertenencia (403) del hábito. • Obtiene set de fechas desde `checkStore` y calcula la racha. • Devuelve `{ habitId, currentStreak, lastCheck? }`.

- Controlador `getHabitStreakHandler` en `habit.controller.ts`: • Llama a `getHabitStreak` y responde 200 con el resultado. • Maneja errores `HttpError` (404/403) y errores genéricos (500).

- Ruta añadida en `habit.routes.ts`: • `GET /api/habits/:habitId/streak` protegida por `authMiddleware`.

- Tests en `tests/habits/getStreak.test.ts`: • Casos para 401 (sin token), 404 (no existe), 403 (otro usuario). • Racha = 0 sin checks, racha = 1 tras un marcado.

- Se actualizó `src/services/habit.service.ts` para exportar `getHabitStreak`.

## Tipo de cambio

- [ ] Arreglo de comportamiento
- [x] Nueva caracteristica
- [ ] Documentación

## Checklist

- [x] He leído CONTRIBUTING.md
- [x] Mi código sigue las pautas de estilo (lint y prettier)
- [x] Añadí tests si son necesarios
- [x] CI pasa sin errores

Close #16 