### PR TITLE
D01 - Ajustar firma de los handlers de categorías

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ npm run test     # ejecuta Jest con coverage
 
 ## Documentación interactiva
 
-La UI de Swagger está disponible en  
+La UI de Swagger está disponible en
+
 ```
 http://localhost:3000/docs
 ```
@@ -41,7 +42,8 @@ http://localhost:3000/docs
 
 ## Autenticación
 
-Todos los endpoints de `/api/habits` requieren un header  
+Todos los endpoints de `/api/habits` requieren un header
+
 ```
 Authorization: Bearer <accessToken>
 ```
@@ -55,6 +57,7 @@ Authorization: Bearer <accessToken>
 Registra un nuevo usuario.
 
 **Request Body**
+
 ```json
 { "email": "user@example.com", "password": "secret123" }
 ```
@@ -62,11 +65,13 @@ Registra un nuevo usuario.
 **Responses**
 
 - **201 Created**
+
   ```json
   { "id": "uuid", "email": "user@example.com" }
   ```
 
 - **400 Bad Request** (validación)
+
   ```json
   { "errors": ["El email no es válido", …] }
   ```
@@ -83,6 +88,7 @@ Registra un nuevo usuario.
 Obtiene tokens JWT.
 
 **Request Body**
+
 ```json
 { "email": "user@example.com", "password": "secret123" }
 ```
@@ -90,11 +96,13 @@ Obtiene tokens JWT.
 **Responses**
 
 - **200 OK**
+
   ```json
   { "accessToken": "<jwt>", "refreshToken": "<refresh_jwt>" }
   ```
 
 - **400 Bad Request** (validación)
+
   ```json
   { "errors": ["El email no es válido", …] }
   ```
@@ -111,6 +119,7 @@ Obtiene tokens JWT.
 Renueva el access token usando el refresh token.
 
 **Request Body**
+
 ```json
 { "refreshToken": "<refresh_jwt>" }
 ```
@@ -118,11 +127,13 @@ Renueva el access token usando el refresh token.
 **Responses**
 
 - **200 OK**
+
   ```json
   { "accessToken": "<nuevo_jwt>" }
   ```
 
 - **400 Bad Request** (missing body)
+
   ```json
   { "message": "refreshToken must be provided" }
   ```
@@ -141,6 +152,7 @@ Renueva el access token usando el refresh token.
 Crea un nuevo hábito.
 
 **Request Body**
+
 ```json
 { "name": "leer diario", "description": "30 min al día" }
 ```
@@ -148,6 +160,7 @@ Crea un nuevo hábito.
 **Responses**
 
 - **201 Created**
+
   ```json
   {
     "id": "uuid",
@@ -183,15 +196,16 @@ Lista todos los hábitos del usuario.
 Actualiza nombre y/o descripción.
 
 **Request Body**
+
 ```json
-{ "name": "nuevo nombre", "description": "…"}
+{ "name": "nuevo nombre", "description": "…" }
 ```
 
 **Responses**
 
-- **200 OK** → objeto `Habit` actualizado.  
-- **400 Bad Request** (validación)  
-- **403 Forbidden** (no es tu hábito)  
+- **200 OK** → objeto `Habit` actualizado.
+- **400 Bad Request** (validación)
+- **403 Forbidden** (no es tu hábito)
 - **404 Not Found** (ID no existe)
 
 ---
@@ -202,8 +216,8 @@ Elimina un hábito.
 
 **Responses**
 
-- **204 No Content**  
-- **403 Forbidden** (no es tu hábito)  
+- **204 No Content**
+- **403 Forbidden** (no es tu hábito)
 - **404 Not Found** (ID no existe)
 
 ---
@@ -215,18 +229,19 @@ Marca el hábito como completado hoy y devuelve la racha.
 **Responses**
 
 - **200 OK**
+
   ```json
   { "habitId": "...", "date": "YYYY-MM-DD", "currentStreak": 3 }
   ```
 
-- **400 Bad Request** (ya marcado hoy)  
-- **403 Forbidden** / **404 Not Found**  
+- **400 Bad Request** (ya marcado hoy)
+- **403 Forbidden** / **404 Not Found**
 
 ---
 
 ### GET `/api/habits/:habitId/streak`
 
- consulta la racha actual sin alterar datos.
+consulta la racha actual sin alterar datos.
 
 **Responses**
 
@@ -235,6 +250,7 @@ Marca el hábito como completado hoy y devuelve la racha.
   { "habitId": "...", "currentStreak": 0 }
   ```
 - **200 OK** (con racha)
+
   ```json
   {
     "habitId": "...",
@@ -243,15 +259,15 @@ Marca el hábito como completado hoy y devuelve la racha.
   }
   ```
 
-- **403 Forbidden** / **404 Not Found**  
+- **403 Forbidden** / **404 Not Found**
 
 ---
 
 ## Cómo Contribuir
 
-1. Lee el [Código de Conducta](./CODE_OF_CONDUCT.md).  
-2. Consulta la guía en [CONTRIBUTING.md](./CONTRIBUTING.md).  
-3. Abre un Issue usando nuestras plantillas en `.github/ISSUE_TEMPLATE/`.  
+1. Lee el [Código de Conducta](./CODE_OF_CONDUCT.md).
+2. Consulta la guía en [CONTRIBUTING.md](./CONTRIBUTING.md).
+3. Abre un Issue usando nuestras plantillas en `.github/ISSUE_TEMPLATE/`.
 4. Envía tu Pull Request con checklist completado.
 
 ---

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,171 +1,484 @@
-openapi: 3.0.1
+openapi: 3.0.3
 info:
   title: Persistual API
-  version: 0.1.0
+  version: '0.2.0'
+  description: API para gestión de hábitos y rachas con autenticación JWT
 servers:
   - url: http://localhost:3000
+    description: Servidor local
+
 paths:
+  /healthz:
+    get:
+      summary: Health check
+      description: Comprueba que el servicio está activo
+      responses:
+        '200':
+          description: OK
+
   /api/auth/register:
     post:
-      summary: Registra un nuevo usuario
-      tags:
-        - auth
+      summary: Registro de usuario
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserDTO'
+              $ref: '#/components/schemas/UserRegister'
       responses:
         '201':
-          description: Usuario creado exitosamente
+          description: Usuario registrado
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserResponse'
         '400':
-          description: Error de validación o email duplicado
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - type: object
-                    properties:
-                      errors:
-                        type: array
-                        items:
-                          type: string
-                  - type: object
-                    properties:
-                      message:
-                        type: string
+          $ref: '#/components/responses/BadRequest'
 
   /api/auth/login:
     post:
-      summary: Autentica un usuario y devuelve JWT
-      tags:
-        - auth
+      summary: Login de usuario
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LoginDTO'
+              $ref: '#/components/schemas/UserLogin'
       responses:
         '200':
-          description: Tokens emitidos
+          description: Tokens de autenticación
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  accessToken:
-                    type: string
-                  refreshToken:
-                    type: string
+                $ref: '#/components/schemas/TokenResponse'
         '400':
-          description: Error de validación
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      type: string
+          $ref: '#/components/responses/BadRequest'
         '401':
-          description: Credenciales inválidas
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
+          $ref: '#/components/responses/Unauthorized'
 
   /api/auth/refresh:
     post:
-      summary: Renueva el access token usando un refresh token
-      tags:
-        - auth
+      summary: Renovación de access token
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                refreshToken:
-                  type: string
+              $ref: '#/components/schemas/RefreshRequest'
       responses:
         '200':
-          description: Nuevo access token emitido
+          description: Nuevo access token
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  accessToken:
-                    type: string
+                $ref: '#/components/schemas/AccessTokenOnly'
         '400':
-          description: Petición mal formada (falta refreshToken)
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
+          $ref: '#/components/responses/BadRequest'
         '401':
-          description: Refresh token inválido o expirado
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/habits:
+    get:
+      summary: Lista hábitos del usuario autenticado
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Lista de hábitos
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
+                type: array
+                items:
+                  $ref: '#/components/schemas/Habit'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    post:
+      summary: Crea un nuevo hábito
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HabitCreate'
+      responses:
+        '201':
+          description: Hábito creado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Habit'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/habits/{habitId}:
+    put:
+      summary: Actualiza un hábito
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: habitId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HabitUpdate'
+      responses:
+        '200':
+          description: Hábito actualizado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Habit'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Elimina un hábito
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: habitId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Hábito eliminado
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/habits/{habitId}/check:
+    post:
+      summary: Marca un hábito para hoy
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: habitId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Hábito marcado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/habits/{habitId}/streak:
+    get:
+      summary: Obtiene la racha actual de un hábito
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: habitId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Racha actual
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreakResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/categories:
+    post:
+      summary: Crea una nueva categoría
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryDTO'
+      responses:
+        '201':
+          description: Categoría creada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    get:
+      summary: Lista todas las categorías
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Lista de categorías
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Category'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/categories/{id}:
+    get:
+      summary: Obtiene una categoría por ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Categoría encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      summary: Actualiza una categoría existente
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategoryDTO'
+      responses:
+        '200':
+          description: Categoría actualizada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Elimina una categoría
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Categoría eliminada
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
   schemas:
-    UserDTO:
+    UserRegister:
       type: object
-      required:
-        - email
-        - password
+      required: [email, password]
       properties:
         email:
           type: string
           format: email
-          example: user@example.com
         password:
           type: string
           minLength: 6
-          example: secret123
 
-    User:
+    UserLogin:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 1
+
+    UserResponse:
       type: object
       properties:
         id:
           type: string
-          format: uuid
-          example: 550e8400-e29b-41d4-a716-446655440000
         email:
           type: string
-          format: email
-          example: user@example.com
 
-    LoginDTO:
+    TokenResponse:
       type: object
-      required:
-        - email
-        - password
       properties:
-        email:
+        accessToken:
           type: string
-          format: email
-          example: user@example.com
-        password:
+        refreshToken:
           type: string
-          example: secret123
+
+    RefreshRequest:
+      type: object
+      required: [refreshToken]
+      properties:
+        refreshToken:
+          type: string
+
+    AccessTokenOnly:
+      type: object
+      properties:
+        accessToken:
+          type: string
+
+    HabitCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 3
+        description:
+          type: string
+
+    HabitUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 3
+        description:
+          type: string
+
+    Habit:
+      allOf:
+        - $ref: '#/components/schemas/HabitCreate'
+        - type: object
+          properties:
+            id:
+              type: string
+            userId:
+              type: string
+            createdAt:
+              type: string
+            description:
+              type: string
+
+    CheckResponse:
+      type: object
+      properties:
+        habitId:
+          type: string
+        date:
+          type: string
+          format: date
+        currentStreak:
+          type: integer
+
+    StreakResponse:
+      type: object
+      properties:
+        habitId:
+          type: string
+        currentStreak:
+          type: integer
+        lastCheck:
+          type: string
+          format: date
+
+    CategoryDTO:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 3
+
+    Category:
+      allOf:
+        - $ref: '#/components/schemas/CategoryDTO'
+        - type: object
+          properties:
+            id:
+              type: string
+            createdAt:
+              type: string
+
+  responses:
+    BadRequest:
+      description: Petición inválida
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  type: string
+    Unauthorized:
+      description: No autorizado
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+    NotFound:
+      description: No encontrado
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string

--- a/package.json
+++ b/package.json
@@ -63,4 +63,3 @@
     "brace-expansion": "1.1.12"
   }
 }
-

--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -1,0 +1,107 @@
+import { RequestHandler } from 'express';
+import { plainToInstance } from 'class-transformer';
+import { validateOrReject } from 'class-validator';
+import { CategoryDTO } from '../models/Category';
+import {
+  createCategory,
+  getCategories,
+  getCategoryById,
+  updateCategory,
+  deleteCategory,
+} from '../services/category.service';
+import { HttpError } from '../services/user.service';
+
+export const createCategoryHandler: RequestHandler = async (req, res) => {
+  try {
+    const dto = plainToInstance(CategoryDTO, req.body);
+    await validateOrReject(dto);
+
+    const cat = createCategory(dto);
+    res.status(201).json(cat);
+    return;
+  } catch (err: unknown) {
+    if (Array.isArray(err)) {
+      const errors = err.flatMap(e =>
+        e.constraints ? Object.values(e.constraints) : [],
+      );
+      res.status(400).json({ errors });
+      return;
+    }
+    if (err instanceof HttpError) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    if (err instanceof Error) {
+      res.status(500).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: 'Error interno' });
+  }
+};
+
+export const getCategoriesHandler: RequestHandler = (_req, res) => {
+  const list = getCategories();
+  res.json(list);
+};
+
+export const getCategoryByIdHandler: RequestHandler = (req, res) => {
+  try {
+    const cat = getCategoryById(req.params.id);
+    res.json(cat);
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    if (err instanceof Error) {
+      res.status(500).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: 'Error interno' });
+  }
+};
+
+export const updateCategoryHandler: RequestHandler = async (req, res) => {
+  try {
+    const dto = plainToInstance(CategoryDTO, req.body);
+    await validateOrReject(dto);
+
+    const cat = updateCategory(req.params.id, dto);
+    res.json(cat);
+    return;
+  } catch (err: unknown) {
+    if (Array.isArray(err)) {
+      const errors = err.flatMap(e =>
+        e.constraints ? Object.values(e.constraints) : [],
+      );
+      res.status(400).json({ errors });
+      return;
+    }
+    if (err instanceof HttpError) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    if (err instanceof Error) {
+      res.status(500).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: 'Error interno' });
+  }
+};
+
+export const deleteCategoryHandler: RequestHandler = (req, res) => {
+  try {
+    deleteCategory(req.params.id);
+    res.sendStatus(204);
+  } catch (err: unknown) {
+    if (err instanceof HttpError) {
+      res.status(err.status).json({ message: err.message });
+      return;
+    }
+    if (err instanceof Error) {
+      res.status(500).json({ message: err.message });
+      return;
+    }
+    res.status(500).json({ message: 'Error interno' });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import YAML from 'yamljs';
 import rateLimit from 'express-rate-limit';
 import authRoutes from './routes/auth.routes';
 import habitRoutes from './routes/habit.routes';
+import categoryRoutes from './routes/category.routes';
 
 const app = express();
 
@@ -43,6 +44,9 @@ app.use('/api', authRoutes);
 
 // Rutas de hábitos (POST /api/habits, etc.)
 app.use('/api/habits', habitRoutes);
+
+// Rutas de categorías (POST /api/categories, etc.)
+app.use('/api', categoryRoutes);
 
 // Exportamos la app para tests
 export default app;

--- a/src/models/Category.ts
+++ b/src/models/Category.ts
@@ -1,0 +1,13 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class CategoryDTO {
+  @IsString({ message: 'El nombre debe ser un texto' })
+  @MinLength(3, { message: 'El nombre debe tener al menos 3 caracteres' })
+  name!: string;
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  createdAt: string;
+}

--- a/src/routes/category.routes.ts
+++ b/src/routes/category.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import {
+  createCategoryHandler,
+  getCategoriesHandler,
+  getCategoryByIdHandler,
+  updateCategoryHandler,
+  deleteCategoryHandler,
+} from '../controllers/category.controller';
+
+const router = Router();
+
+router.post('/categories', createCategoryHandler);
+router.get('/categories', getCategoriesHandler);
+router.get('/categories/:id', getCategoryByIdHandler);
+router.put('/categories/:id', updateCategoryHandler);
+router.delete('/categories/:id', deleteCategoryHandler);
+
+export default router;

--- a/src/services/category.service.ts
+++ b/src/services/category.service.ts
@@ -1,0 +1,46 @@
+import { v4 as uuid } from 'uuid';
+import { Category, CategoryDTO } from '../models/Category';
+import { HttpError } from './user.service';
+
+const categoryStore = new Map<string, Category>();
+
+export function createCategory(dto: CategoryDTO): Category {
+  // Opcional: verificar duplicados por nombre
+  if ([...categoryStore.values()].some(c => c.name === dto.name)) {
+    throw new HttpError('Categoría ya existe', 400);
+  }
+  const cat: Category = {
+    id: uuid(),
+    name: dto.name,
+    createdAt: new Date().toISOString(),
+  };
+  categoryStore.set(cat.id, cat);
+  return cat;
+}
+
+export function getCategories(): Category[] {
+  return Array.from(categoryStore.values());
+}
+
+export function getCategoryById(id: string): Category {
+  const cat = categoryStore.get(id);
+  if (!cat) throw new HttpError('Categoría no encontrada', 404);
+  return cat;
+}
+
+export function updateCategory(
+  id: string,
+  dto: Partial<CategoryDTO>,
+): Category {
+  const cat = getCategoryById(id);
+  if (dto.name) {
+    cat.name = dto.name;
+  }
+  return cat;
+}
+
+export function deleteCategory(id: string): void {
+  if (!categoryStore.delete(id)) {
+    throw new HttpError('Categoría no encontrada', 404);
+  }
+}

--- a/tests/categories/category.test.ts
+++ b/tests/categories/category.test.ts
@@ -1,0 +1,115 @@
+import request from 'supertest';
+import app from '../../src/index';
+import { createUser } from '../../src/services/user.service';
+
+describe('CRUD de Categorías (/api/categories)', () => {
+  let token: string;
+  let categoryId: string;
+
+  beforeAll(async () => {
+    // 1) Crea un usuario de prueba
+    const email = 'cat@test.com';
+    const password = 'secret123';
+    await createUser(email, password);
+
+    // 2) Haz login para obtener el accessToken
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email, password });
+    token = res.body.accessToken;
+  });
+
+  it('POST /api/categories → 201 y objeto categoría', async () => {
+    const res = await request(app)
+      .post('/api/categories')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Salud' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+    expect(res.body.name).toBe('Salud');
+    categoryId = res.body.id;
+  });
+
+  it('POST /api/categories → 400 si nombre muy corto', async () => {
+    const res = await request(app)
+      .post('/api/categories')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'AB' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toContain(
+      'El nombre debe tener al menos 3 caracteres',
+    );
+  });
+
+  it('GET /api/categories → 200 y lista incluye la categoría creada', async () => {
+    const res = await request(app)
+      .get('/api/categories')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    // Casteamos a un arreglo de objetos que al menos tienen id
+    const categories = res.body as Array<{ id: string }>;
+    expect(categories.some(c => c.id === categoryId)).toBe(true);
+  });
+
+  it('GET /api/categories/:id → 200 y devuelve la categoría correcta', async () => {
+    const res = await request(app)
+      .get(`/api/categories/${categoryId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(categoryId);
+    expect(res.body.name).toBe('Salud');
+  });
+
+  it('GET /api/categories/:id → 404 si no existe', async () => {
+    const res = await request(app)
+      .get('/api/categories/404-not-found')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Categoría no encontrada');
+  });
+
+  it('PUT /api/categories/:id → 200 y actualiza correctamente', async () => {
+    const res = await request(app)
+      .put(`/api/categories/${categoryId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Salud Mental' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(categoryId);
+    expect(res.body.name).toBe('Salud Mental');
+  });
+
+  it('PUT /api/categories/:id → 400 si nombre inválido', async () => {
+    const res = await request(app)
+      .put(`/api/categories/${categoryId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toContain(
+      'El nombre debe tener al menos 3 caracteres',
+    );
+  });
+
+  it('DELETE /api/categories/:id → 204 elimina la categoría', async () => {
+    const res = await request(app)
+      .delete(`/api/categories/${categoryId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(204);
+  });
+
+  it('DELETE /api/categories/:id → 404 si ya no existe', async () => {
+    const res = await request(app)
+      .delete(`/api/categories/${categoryId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Categoría no encontrada');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Descripción

- Modifica todos los handlers de src/controllers/category.controller.ts para que no devuelvan directamente el objeto Response, sino que invoquen res.*() y hagan un return; para cumplir con el tipo void | Promise<void> de RequestHandler.

- Elimina los retornos de return res.json(…), return res.status(…).json(…), etc., dejando sólo la llamada a res y un return; posterior donde era necesario.

- Conserva intacta la lógica de validación con class-validator y el manejo de errores (HttpError y genéricos), asegurando que todos los paths terminan con un res.status(...) o res.sendStatus(...).

## Tipo de cambio

- [ ] Arreglo de comportamiento
- [X] Nueva caracteristica
- [ ] Documentación

## Checklist

- [X] He leído CONTRIBUTING.md
- [X] Mi código sigue las pautas de estilo (lint y prettier)
- [X] Añadí tests si son necesarios
- [X] CI pasa sin errores

closes #22 