### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/src/routes/notification.routes.ts
+++ b/src/routes/notification.routes.ts
@@ -1,13 +1,21 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import {
   createNotificationHandler,
   deleteNotificationHandler,
 } from '../controllers/notification.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 
+// Rate limiter for delete notification route
+const deleteNotificationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 delete requests per windowMs
+  message: 'Too many delete requests from this IP, please try again later.',
+});
+
 const router = Router();
 
 router.post('/notifications', authMiddleware, createNotificationHandler);
-router.delete('/notifications/:id', authMiddleware, deleteNotificationHandler);
+router.delete('/notifications/:id', authMiddleware, deleteNotificationLimiter, deleteNotificationHandler);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/JoelBuenrostro/persistual-api/security/code-scanning/20](https://github.com/JoelBuenrostro/persistual-api/security/code-scanning/20)

To fix the missing rate limiting, we should add a rate-limiting middleware to the DELETE `/notifications/:id` route. The best practice is to use a well-known library such as `express-rate-limit`. We will import this package, define a rate limiter (e.g., allowing a reasonable number of delete requests per user per time window), and apply it specifically to the DELETE route. This avoids affecting other routes unnecessarily and preserves existing functionality. The changes should be made in `src/routes/notification.routes.ts` by importing `express-rate-limit`, defining a limiter, and adding it to the middleware chain for the DELETE route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
